### PR TITLE
Adding groupInfo to the user data kept in local storage

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -42,12 +42,21 @@ function App() {
     }
   });
 
+  const [groupInfo, setGroupInfo] = useState(() => {
+    if(!window.localStorage.getItem('groupInfo')) {
+      return [];
+    } else {
+      return JSON.parse(window.localStorage.getItem('groupInfo'));
+    }
+  });
+
   useEffect(()=>{
     window.localStorage.setItem('userId',userId);
     window.localStorage.setItem('token',token);
     window.localStorage.setItem('email',email);
     window.localStorage.setItem('fullName',fullName);
-  },[token, userId, email, fullName]);
+    window.localStorage.setItem('groupInfo', JSON.stringify(groupInfo));
+  },[token, userId, email, fullName, groupInfo]);
 
 
   const loginUser = async (loginData) => {
@@ -56,12 +65,12 @@ function App() {
       console.log('inside login function');
       let res = await CaregiverApi.loginUser(loginData);
       // window.localStorage.setItem('token',res.token);
-
       // // set all corresponding data
       setToken(res.token);
       setUserId(res.id);
       setEmail(res.email);
       setFullName(res.fullName);
+      setGroupInfo(res.groupInfo);
       
       return res.id;
     }catch(err){
@@ -81,6 +90,7 @@ function App() {
       setUserId(res.user._id);
       setEmail(res.user.email);
       setFullName(res.user.fullName);
+      setGroupInfo(res.user.groupInfo);
       return res;
     } catch (err) {
       return err;
@@ -93,6 +103,7 @@ function App() {
     setUserId(null);
     setEmail('');
     setFullName('');
+    setGroupInfo('');
   }
 
   CaregiverApi.token = token;
@@ -102,7 +113,7 @@ function App() {
 
       <BrowserRouter> 
 
-        <UserContext.Provider value={{token, userId, email, fullName, loginUser, logoutUser ,registerUser}}>
+        <UserContext.Provider value={{token, userId, email, fullName, groupInfo, loginUser, logoutUser ,registerUser}}>
 
           <Navbar/>
           <FrontendRoutes/>

--- a/client/src/components/GroupPages/RegisterPage/Register.js
+++ b/client/src/components/GroupPages/RegisterPage/Register.js
@@ -51,10 +51,10 @@ function Register() {
         if (Object.keys(formErrors).length === 0 && isSubmit) {
             console.log(formData);
         }
-        if (token) {
-          // Redirect the user to the previous page
-          navigate(-1);
-        }
+        // if (token) {
+        //   // Redirect the user to the previous page
+        //   navigate(-1);
+        // }
     }, [token, navigate]);
 
     const validate = data => {

--- a/server/controllers/homeController.js
+++ b/server/controllers/homeController.js
@@ -25,7 +25,7 @@ module.exports = {
                 phoneNumber: phoneNumber,
                 email: email,
                 password: hashedPassword,
-                groupInfo: {}
+                groupInfo: []
             })
 
             // create token by sign data to return (payload) with the secret key

--- a/server/controllers/loginController.js
+++ b/server/controllers/loginController.js
@@ -30,7 +30,7 @@ module.exports = {
             
 
             const token = jwt.sign({id:user.id, fullName:user.fullName, email:user.email},SECRET_KEY);
-            return res.status(201).json({id:user[0].id, fullName:user[0].fullName, email:user[0].email, token});
+            return res.status(201).json({id:user[0].id, fullName:user[0].fullName, email:user[0].email, token, groupInfo:user[0].groupInfo});
 
         } catch (err) {
             console.error(err);

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -21,7 +21,6 @@ const UserSchema = new mongoose.Schema( {
     //this will be an assigment
     token: {
         type: String,
-        default: null
     },
     groupInfo: [{
         groupId: {


### PR DESCRIPTION
These changes make it possible to store a user's group information (i.e., what groups they belong to and what roles they play in those groups) in UserContext and local storage so that we can reduce back-end API calls. I also made a couple small changes to address some bugs that I found when trying to register as a new user and test the groupInfo feature.