### PR TITLE
Refactoring group create and group display to incorporate requests

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -113,7 +113,7 @@ function App() {
 
       <BrowserRouter> 
 
-        <UserContext.Provider value={{token, userId, email, fullName, groupInfo, loginUser, logoutUser ,registerUser}}>
+        <UserContext.Provider value={{token, userId, email, fullName, groupInfo, setGroupInfo, loginUser, logoutUser ,registerUser}}>
 
           <Navbar/>
           <FrontendRoutes/>

--- a/client/src/components/GroupPages/GroupCreationPage/groupForm.js
+++ b/client/src/components/GroupPages/GroupCreationPage/groupForm.js
@@ -2,11 +2,9 @@ import React, { useContext, useState } from 'react';
 import { useNavigate } from "react-router-dom";
 import UserContext from '../../../UserContext';
 import CaregiverApi from '../../../api';
-import axios from 'axios';
 
 function GroupForm() {
-    const { userId } = useContext(UserContext);
-    const { fullName } = useContext(UserContext);
+    const { userId, fullName, groupInfo, setGroupInfo } = useContext(UserContext);
     const navigate = useNavigate();
     const [formData, setFormData] = useState({
         groupName: "",
@@ -14,12 +12,13 @@ function GroupForm() {
         description: ""
     });
 
-    const handleSubmit = (e) => {
+    const handleSubmit = async e => {
         e.preventDefault();
-        let groupId = "";
-        CaregiverApi.createGroup( {user_id: userId, user_fullName: fullName, patientName: formData.patientName, description: formData.description} )
-        .then(data => groupId = data)
-        .then(setTimeout( () => navigate("/groupViewSingle/" + groupId), 1500) ); //navigated before database is updated so added 1.5 sec delay
+        let res = await CaregiverApi.createGroup( {user_id: userId, user_fullName: fullName, patientName: formData.patientName, description: formData.description} )
+        const groupId = res;
+        const updatedGroupInfo = [ ...groupInfo, { groupId: groupId, userRole: "Caregiver"} ];
+        setGroupInfo(updatedGroupInfo);
+        navigate("/groupViewSingle/" + groupId);
     };
 
     return (
@@ -30,7 +29,7 @@ function GroupForm() {
                 <input size="40" className="border-2 rounded-[5px] border-gray-300 outline outline-0 py-[10px] px-[20px] mb-[18px]" type="text" onChange={ (e) => setFormData({...formData, patientName: e.target.value})} value={formData.patientName} placeholder="Patient's Name" required/>
                 <br/>
                 <div className="border-2 rounded-[5px] border-gray-300 mx-[41px] mb-[28px]">
-                    <textArea rows="4" cols="38" className="outline outline-0 py-[12px] px-[20px] resize-none" maxlength="500" type="text" onChange={ (e) => setFormData({...formData, description: e.target.value})} value={formData.description} placeholder="Describe the Purpose of the Group" required/>
+                    <textarea rows="4" cols="38" className="outline outline-0 py-[12px] px-[20px] resize-none" maxLength="500" type="text" onChange={ (e) => setFormData({...formData, description: e.target.value})} value={formData.description} placeholder="Describe the Purpose of the Group" required/>
                     <p className=" text-[12px] text-gray-400 text-right pb-[4px] pr-[6px]">{formData.description.length} / 500</p>
                 </div>
                 <div className="flex flex-col py-[5px] px-[40px] float-right">

--- a/client/src/components/GroupPages/GroupEditDeletePage/groupEditDelete.js
+++ b/client/src/components/GroupPages/GroupEditDeletePage/groupEditDelete.js
@@ -38,7 +38,7 @@ function GroupEditDelete() {
                 <input size="40" className="border-2 rounded-[5px] border-gray-300 outline outline-0 py-[10px] px-[20px] mb-[18px]" type="text" onChange={ (e) => setFormData({...formData, patientName: e.target.value})} value={formData.patientName} placeholder="Patient's Name" required/>
                 <br/>
                 <div className="border-2 rounded-[5px] border-gray-300 mx-[41px] mb-[28px]">
-                    <textArea rows="4" cols="38" className="outline outline-0 py-[12px] px-[20px] resize-none" maxlength="500" type="text" onChange={ (e) => setFormData({...formData, description: e.target.value})} value={formData.description} placeholder="Description" required/>
+                    <textarea rows="4" cols="38" className="outline outline-0 py-[12px] px-[20px] resize-none" maxLength="500" type="text" onChange={ (e) => setFormData({...formData, description: e.target.value})} value={formData.description} placeholder="Description" required/>
                     <p className=" text-[12px] text-gray-400 text-right pb-[4px] pr-[6px]">{formData.description.length} / 500</p>
                 </div>
                 <div className="flex flex-col py-[5px] px-[40px] float-right">

--- a/client/src/components/GroupPages/GroupViewSinglePage/Information.js
+++ b/client/src/components/GroupPages/GroupViewSinglePage/Information.js
@@ -2,24 +2,33 @@ import React, { useContext, useState, useEffect } from 'react';
 import { useParams, useNavigate } from "react-router-dom";
 import UserContext from '../../../UserContext';
 import CaregiverApi from '../../../api';
-import axios from 'axios';
+import RequestDisplayTable from '../RequestPage/RequestDisplayTable';
 
 const Information = () => {
-    const [groupData, setGroupData] = useState([]);
-    const [userStatus, setUserStatus] = useState([]);
+    const [groupData, setGroupData] = useState();
+    const [userRole, setUserRole] = useState('');
+    const [requests, setRequests] = useState([]);
     const { groupId } = useParams();
-    const { userId } = useContext(UserContext);
+    const { userId, groupInfo } = useContext(UserContext);
     const navigate = useNavigate();
 
-    const fetchData = () => {
-        CaregiverApi.getIndividualGroup( {group_id: groupId} )
-        .then(data => setGroupData(data))
-        .then(checkUser());
+    const [isLoaded, setIsLoaded] = useState(false);
+
+    function getUserRole(groupId, groupInfo) {
+        let userRole = '';
+        if (!groupInfo) return userRole;
+        for (let i = 0; i < groupInfo.length; i++) {
+            if (groupInfo[i].groupId === groupId) {
+                setUserRole(groupInfo[i].userRole);
+            }
+        }
+        console.log(userRole);
+        return userRole;
     }
 
-    function checkUser() {
-        CaregiverApi.checkUser( {user_id: userId, group_id: groupId} )
-        .then(data => setUserStatus(data) );
+    const handleAddRequestButton = () => {
+        setIsLoaded(false);
+        navigate(`/groups/${groupId}/request/create`);
     }
 
     function joinGroup() { //reload page after?
@@ -27,24 +36,49 @@ const Information = () => {
     }
 
     useEffect(() => {
+        async function fetchData() {
+            let res = await CaregiverApi.getIndividualGroup( {group_id: groupId} );
+            setGroupData(res);
+            getUserRole(groupId, groupInfo);
+            let requests = await CaregiverApi.findAllRequestsForOneGroup(groupId);
+            setRequests(requests);
+            setIsLoaded(true);
+        }
         fetchData();
     }, []);
 
     let roleButton;
-    if (userStatus === 'Caregiver') {
+    if (userRole === 'Caregiver') {
         roleButton = <button onClick={() => navigate("/GroupEditDelete/" + groupId )}>Edit Details</button>;
-    } else if (userStatus !== 'Caregiver' && userStatus !== 'Support') {
+    } else if (userRole !== 'Caregiver' && userRole !== 'Support') {
         roleButton = <button onClick={() => joinGroup()}>Join Group</button>;
     }
 
     return (
-        <div>
-            <h1>{groupData.nameGroup}</h1>
-            <h2>{groupData.namePatient}</h2>
-            {roleButton}
-            <p>Caregiver: {groupData.nameCaregiver}</p>
-            <p>Description: {groupData.description}</p>
-        </div>
+        <>
+            {isLoaded && (
+                <>
+                    <div>
+                        <h1>{groupData.namePatient}</h1>
+                        {roleButton}
+                        <p>Caregiver: {groupData.nameCaregiver}</p>
+                        <p>Description: {groupData.description}</p>
+                    </div>
+                    {userRole === "Caregiver" ? 
+                        <button onClick={handleAddRequestButton}>Add Request</button> :
+                        <></>
+                    }
+                    {(requests && requests.length > 0) ? 
+                        <RequestDisplayTable userRole={userRole} requests={requests} setRequests={setRequests} />
+                        :
+                        (userRole === "Caregiver") ? 
+                            <p>Click the "Add Request" button to begin adding support requests to your group.</p> :
+                            <p>No support requests yet.</p>
+                    }
+                    
+                </>
+            )}
+        </>
     );
 };
 

--- a/client/src/components/GroupPages/RequestPage/RequestCreate.js
+++ b/client/src/components/GroupPages/RequestPage/RequestCreate.js
@@ -79,7 +79,7 @@ const RequestCreate = () => {
         let res = await CaregiverApi.createRequest(updatedRequestData);
         if (typeof res.error === 'undefined') {
             setRequestData(INITIAL_STATE);
-            navigate('/login');
+            navigate(`/groupViewSingle/${groupId}`);
         } else {
             setHasError(true);
             setErrorMessage(res.error.message);

--- a/client/src/components/GroupPages/RequestPage/RequestEdit.js
+++ b/client/src/components/GroupPages/RequestPage/RequestEdit.js
@@ -5,7 +5,7 @@ import CaregiverApi from '../../../api';
 import { DateTime } from 'luxon';
 import validator from 'validator';
 
-const RequestEdit = () => {
+const RequestEdit = (props) => {
     
     // grab the group id from the parameter variable
     const { groupId } = useParams();
@@ -14,9 +14,6 @@ const RequestEdit = () => {
     const location = useLocation();
     const requestId = location.state.requestId;
 
-    // get the user id from UserContext
-    const { userId } = useContext(UserContext);
-
     const navigate = useNavigate();
 
     const [data, setData] = useState({
@@ -24,8 +21,7 @@ const RequestEdit = () => {
         errorMessage: [],
         requestData: {},
         isLoaded: false
-    })
-    console.log(data);
+    });
 
     // create currentDate variable to use as the minimum value for the date input
     const currentDate = DateTime.now() // create DateTime object
@@ -88,11 +84,13 @@ const RequestEdit = () => {
         e.preventDefault();
         const { dateNeeded, timeNeeded } = data.requestData;
         const dateTimeUTC = createDateTimeUTC(dateNeeded, timeNeeded);
-        const updatedRequestData = { ...data, requestData: { ...data.requestData, dateTimeUTC: dateTimeUTC}};
+        // creating updated data object
+        const updatedRequestData = { ...data, requestData: { ...data.requestData, dateTimeUTC: dateTimeUTC }};
+        // setting updated request data object in state
         setData(updatedRequestData);
-        const res = await CaregiverApi.updateOneRequest(requestId, data.requestData);
+        const res = await CaregiverApi.updateOneRequest(requestId, updatedRequestData.requestData);
         if (typeof res.error === 'undefined') {
-            navigate(`/groups/${groupId}`);
+            navigate(`/groupViewSingle/${groupId}`);
         } else {
             setData({ ...data, hasError: true, errorMessage: res.error.message});
             console.log(data.errorMessage);


### PR DESCRIPTION
This pull requests integrates the requests table into the individual group view. It also does some other refactoring (for example, I removed the setTimeout function when a group is created and instead used an asynchronous function). A user is now able to create a group and add requests to that group. I have not yet integrated the sign up feature yet.