### PR TITLE
Changed 'groupInfo.groupId' to 'groupInfo._id' so '_id' could be extr…

### DIFF
--- a/client/src/components/GroupPages/GroupCreationPage/groupForm.js
+++ b/client/src/components/GroupPages/GroupCreationPage/groupForm.js
@@ -15,7 +15,7 @@ function GroupForm() {
         e.preventDefault();
         let res = await CaregiverApi.createGroup( {user_id: userId, user_fullName: fullName, patientName: formData.patientName, description: formData.description} )
         const groupId = res;
-        const updatedGroupInfo = [ ...groupInfo, { groupId: groupId, userRole: "Caregiver"} ];
+        const updatedGroupInfo = [ ...groupInfo, { _id: groupId, userRole: "Caregiver"} ];
         setGroupInfo(updatedGroupInfo);
         navigate("/groupViewSingle/" + groupId);
     };

--- a/client/src/components/GroupPages/GroupViewSinglePage/Information.js
+++ b/client/src/components/GroupPages/GroupViewSinglePage/Information.js
@@ -18,7 +18,7 @@ const Information = () => {
         let userRole = '';
         if (!groupInfo) return userRole;
         for (let i = 0; i < groupInfo.length; i++) {
-            if (groupInfo[i].groupId === groupId) {
+            if (groupInfo[i]._id === groupId) {
                 setUserRole(groupInfo[i].userRole);
             }
         }
@@ -41,7 +41,7 @@ const Information = () => {
                 namePatient: groupData.namePatient
             }
         );
-        const updatedGroupInfo = [ ...groupInfo, { groupId: groupId, userRole: "Support"} ];
+        const updatedGroupInfo = [ ...groupInfo, { _id: groupId, userRole: "Support"} ];
         setGroupInfo(updatedGroupInfo);
         getUserRole(groupId, updatedGroupInfo);
     }

--- a/server/controllers/individualGroupController.js
+++ b/server/controllers/individualGroupController.js
@@ -16,7 +16,7 @@ async function createGroup(req,res) {
         let memberId = new mongoose.Types.ObjectId(req.body.user_id);
         let member = await users.findOne(memberId);
         member.groupInfo.push({
-            groupId : newGroup._id,
+            _id : newGroup._id,
             userRole : "Caregiver",
             nameCaregiver : req.body.user_fullName,
             namePatient : req.body.patientName,
@@ -39,7 +39,7 @@ async function joinGroup(req,res) { //add check if already joined group?
         let memberId = new mongoose.Types.ObjectId(req.body.user_id);
         let member = await users.findOne(memberId);
         member.groupInfo.push({
-            groupId : req.body.group_id,
+            _id : req.body.group_id,
             userRole : "Support",
             nameCaregiver: nameCaregiver,
             namePatient: namePatient,
@@ -76,8 +76,8 @@ async function deleteGroup(req,res) {
         let refId = new mongoose.Types.ObjectId(req.body.group_id);
         await groups.findOneAndDelete( {_id: refId} );
         await users.updateMany(
-            { groupInfo: {$elemMatch: { groupId: req.body.group_id } } },
-            { $pull: { groupInfo: { groupId: req.body.group_id } } }
+            { groupInfo: {$elemMatch: { _id: req.body.group_id } } },
+            { $pull: { groupInfo: { _id: req.body.group_id } } }
         );
 
         res.status(204);
@@ -93,11 +93,11 @@ async function checkUserGroup(req,res) {
     try {
         let userRole = "Unknown";
         memberId = new mongoose.Types.ObjectId(req.query.user_id);
-        let member = await users.findOne( {_id: memberId, groupInfo: {$elemMatch: {groupId: req.query.group_id} } } );
+        let member = await users.findOne( {_id: memberId, groupInfo: {$elemMatch: {_id: req.query.group_id} } } );
         if(member != null) {
             let i = 0
             while(member.groupInfo[i] !== undefined && userRole === "Unknown") { //iterate through groupInfo array
-                if(member.groupInfo[i].groupId === req.query.group_id) {
+                if(member.groupInfo[i]._id === req.query.group_id) {
                     userRole = member.groupInfo[i].userRole;
                 }
                 i++;

--- a/server/models/userModel.js
+++ b/server/models/userModel.js
@@ -23,7 +23,7 @@ const UserSchema = new mongoose.Schema( {
         type: String,
     },
     groupInfo: [{
-        groupId: {
+        _id: {
             type: String,
         },
         userRole: {


### PR DESCRIPTION
Details of groups from /userGroups route could not be viewed.  Issue was different variable names within shared components.  Changed 'groupInfo.groupId' to 'groupInfo._id' so '_id' could be extracted in 'ChildGroupTable.js'.


**Note: Old users in database will need to be deleted.  There will no longer be a groupInfo.groupId variable to reference.