### PR TITLE
Fixing register route and handleSubmit in Register.js

### DIFF
--- a/client/src/components/GroupPages/RegisterPage/Register.js
+++ b/client/src/components/GroupPages/RegisterPage/Register.js
@@ -27,9 +27,10 @@ function Register() {
         if (Object.keys(formErrors).length === 0) {
           let response = await registerUser(formData); // Use registerUser for registration
           setIsSubmit(true);
-          if(response.response.status === 409) { // Notifies user if fullname or email is already taken
-            if(response.response.data === 'User already exists with this name.') setFormErrors({fullName: response.response.data});
-            else setFormErrors({email: response.response.data});
+          console.log(response);
+          if(response.status === 409) { // Notifies user if fullname or email is already taken
+            if(response.data === 'User already exists with this name.') setFormErrors({fullName: response.data});
+            else setFormErrors({email: response.data});
           } else if (response.status === 201) { // Handle success or redirect as needed
             console.log('Registration successful');
             setFormData(INITIAL_STATE);

--- a/client/src/components/GroupPages/RegisterPage/Register.js
+++ b/client/src/components/GroupPages/RegisterPage/Register.js
@@ -27,7 +27,6 @@ function Register() {
         if (Object.keys(formErrors).length === 0) {
           let response = await registerUser(formData); // Use registerUser for registration
           setIsSubmit(true);
-          console.log(response);
           if(response.status === 409) { // Notifies user if fullname or email is already taken
             if(response.data === 'User already exists with this name.') setFormErrors({fullName: response.data});
             else setFormErrors({email: response.data});

--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -4,7 +4,7 @@ const homeController = require('../controllers/homeController');
 const { ensureLoggedIn } = require('../middleware/authorization');
 
 //Routes for main examples: landing page, login/register
-router.post('/register', ensureLoggedIn, homeController.createUser);
+router.post('/register', homeController.createUser);
 router.get('/user/getInfo/:userId', ensureLoggedIn, homeController.getUserInfo);
 router.get('/editUser/:id', ensureLoggedIn, homeController.getUserProfile);
 router.patch('/editUser/:id', ensureLoggedIn, homeController.updateUserProfile);


### PR DESCRIPTION
I removed the `ensureLoggedIn` middleware call from the register route in `server/routes/main.js`. This middleware call was prohibiting registering as a new user. I also edited the conditional statements in the `handleSubmit` function in `client/src/components/GroupPages/RegisterPage/Register.js` from, e.g., `response.response.status` to `response.status`, since the response object doesn't have a nested response object inside it. I checked to make sure the error messages were being rendered properly on the register screen.